### PR TITLE
Major rewrite

### DIFF
--- a/src/Button/Button.stories.tsx
+++ b/src/Button/Button.stories.tsx
@@ -6,7 +6,8 @@ import { config } from 'storybook-addon-designs'
 import withGrid from '../_internal/StorybookGrid'
 import Icon from '../Icon'
 
-import Button, { ButtonProps } from './index'
+import Button from './Button'
+import ButtonProps from './Button.interface'
 
 const GRID_PROPS = {
   children: 'Voir tous nos projets',
@@ -48,24 +49,6 @@ const GRID_LINES = [
     title: 'Link + Large',
     props: { link: true, large: true },
   },
-  {
-    title: 'Colored background + Solid',
-    coloredBackground: true,
-  },
-  {
-    title: 'Colored background + Outline',
-    props: {
-      outline: true,
-    },
-    coloredBackground: true,
-  },
-  {
-    title: 'Colored background + Link',
-    props: {
-      link: true,
-    },
-    coloredBackground: true,
-  },
 ]
 
 const GRID_ITEMS = [
@@ -106,6 +89,8 @@ storiesOf('Actions|Button', module)
         'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=18%3A1250',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <Button
       outline={boolean('Outline', false)}

--- a/src/Card/Card.stories.tsx
+++ b/src/Card/Card.stories.tsx
@@ -56,15 +56,7 @@ const GRID_PROPS = {
   children: <CardChildren />,
 }
 
-const GRID_LINES = [
-  {
-    title: 'White background',
-  },
-  {
-    title: 'Colored background',
-    coloredBackground: true,
-  },
-]
+const GRID_LINES = [{}]
 
 const GRID_ITEMS = [
   {
@@ -99,6 +91,8 @@ storiesOf('Miscellaneous|Card', module)
         'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=4%3A0',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <Card animated={boolean('Animated', false)} flat={boolean('Flat', false)}>
       <CardChildren />

--- a/src/Card/Card.style.ts
+++ b/src/Card/Card.style.ts
@@ -10,7 +10,7 @@ export const CardContainer = styled(Background)`
   transition: all 150ms ease-in-out;
 
   &:not([data-flat='true']) {
-    box-shadow: ${theme.shadow('regular')};
+    box-shadow: ${theme.shadow('low')};
   }
 
   &[data-animated='true'] {
@@ -19,7 +19,7 @@ export const CardContainer = styled(Background)`
       transform: translateY(-4px);
 
       &:not([data-flat='true']) {
-        box-shadow: ${theme.shadow('regular', { hover: true })};
+        box-shadow: ${theme.shadow('low', { hover: true })};
       }
     }
   }

--- a/src/Card/Card.tsx
+++ b/src/Card/Card.tsx
@@ -1,10 +1,14 @@
 import * as React from 'react'
 
+import useTheme from '../useTheme'
+
 import CardProps from './Card.interface'
 import { CardContainer } from './Card.style'
 
 const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
   const { animated, flat, children, ...rest } = props
+
+  const theme = useTheme()
 
   return (
     <CardContainer
@@ -12,7 +16,7 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>((props, ref) => {
       {...rest}
       data-animated={animated}
       data-flat={flat}
-      backgroundColor="#FFFFFF"
+      backgroundColor={theme.backgroundColor}
     >
       {children}
     </CardContainer>

--- a/src/Checkbox/Checkbox.stories.tsx
+++ b/src/Checkbox/Checkbox.stories.tsx
@@ -24,10 +24,6 @@ const GRID_LINES = [
   {
     title: 'Regular',
   },
-  {
-    title: 'Colored background',
-    coloredBackground: true,
-  },
 ]
 
 const GRID_ITEMS = [
@@ -71,6 +67,8 @@ storiesOf('Input|Checkbox', module)
         'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=62%3A0',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <CheckboxContainer>
       <Checkbox

--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
+import useHasColoredBackground from '../_internal/useHasColoredBackground'
 import useUniqID from '../_internal/useUniqId'
-import useTheme from '../useTheme'
 
 import CheckboxProps from './Checkbox.interface'
 import { Input, FakeInputContainer, FakeInput } from './Checkbox.style'
@@ -10,14 +10,15 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
   (props, ref) => {
     const { error, value, checked, disabled, id, ...rest } = props
     const checkboxId = useUniqID(id)
-    const theme = useTheme()
+    const hasBackground = useHasColoredBackground()
+
     return (
       <FakeInputContainer>
         <Input
           ref={ref}
           {...rest}
           data-error={error}
-          data-background={theme.backgroundColor !== '#FFFFFF'}
+          data-background={hasBackground}
           checked={!!value || !!checked}
           disabled={disabled}
           type="checkbox"

--- a/src/FloatingButton/FloatingButton.tsx
+++ b/src/FloatingButton/FloatingButton.tsx
@@ -11,9 +11,9 @@ const FloatingButton = React.forwardRef<HTMLButtonElement, FloatingButtonProps>(
   (props, ref) => {
     const {
       children,
-      small,
       elementLeft,
       elementRight,
+      small = false,
       fixed = false,
       position = 'bottom',
       ...rest

--- a/src/FloatingIconButton/FloatingIconButton.interface.ts
+++ b/src/FloatingIconButton/FloatingIconButton.interface.ts
@@ -1,0 +1,10 @@
+import { Button, styledAs } from '../_internal/types'
+import { IconProps } from '../Icon'
+
+export default interface FloatingIconButtonProps
+  extends Omit<Button, 'large' | 'small'>,
+    Pick<IconProps, 'icon' | 'colored'> {
+  position?: 'bottom-left' | 'bottom-right'
+  fixed?: boolean
+  as?: styledAs
+}

--- a/src/FloatingIconButton/FloatingIconButton.stories.tsx
+++ b/src/FloatingIconButton/FloatingIconButton.stories.tsx
@@ -6,24 +6,23 @@ import styled from 'styled-components'
 
 import withGrid from '../_internal/StorybookGrid'
 import Card from '../Card'
-import Icon from '../Icon'
 
-import BaseFloatingButton from './FloatingButton'
-import FloatingButtonProps from './FloatingButton.interface'
+import BaseFloatingIconButton from './FloatingIconButton'
+import FloatingIconButtonProps from './FloatingIconButton.interface'
 
 const Container = styled(Card)`
   width: 300px;
   height: 200px;
 `
 
-const FloatingButton: React.FunctionComponent<FloatingButtonProps> = props => (
+const FloatingIconButton: React.FunctionComponent<FloatingIconButtonProps> = props => (
   <Container>
-    <BaseFloatingButton {...props} />
+    <BaseFloatingIconButton {...props} />
   </Container>
 )
 
 const GRID_PROPS = {
-  children: 'Liste',
+  icon: 'list',
 }
 
 const GRID_LINES = [
@@ -31,12 +30,8 @@ const GRID_LINES = [
     title: 'Regular',
   },
   {
-    title: 'Small',
-    props: { small: true },
-  },
-  {
-    title: 'Position top',
-    props: { position: 'top' as 'top' },
+    title: 'Position bottom left',
+    props: { position: 'bottom-left' as 'bottom-left' },
   },
 ]
 
@@ -47,34 +42,23 @@ const GRID_ITEMS = [
   },
   {
     props: {
-      elementLeft: <Icon icon="list" />,
-    },
-  },
-  {
-    props: {
-      elementRight: <Icon icon="list" />,
-    },
-  },
-  {
-    props: {
       warning: true,
-      children: 'Supprimer',
     },
   },
 ]
 
-const Grid = withGrid<FloatingButtonProps>({
+const Grid = withGrid<FloatingIconButtonProps>({
   props: GRID_PROPS,
   lines: GRID_LINES,
   items: GRID_ITEMS,
-})(FloatingButton)
+})(FloatingIconButton)
 
-const positions: { [key: string]: 'top' | 'bottom' } = {
-  Top: 'top',
-  Bottom: 'bottom',
+const positions: { [key: string]: 'bottom-left' | 'bottom-right' } = {
+  'Bottom Left': 'bottom-left',
+  'Bottom Right': 'bottom-right',
 }
 
-storiesOf('Actions|FloatingButton', module)
+storiesOf('Actions|FloatingIconButton', module)
   .addDecorator(withKnobs)
   .add('gallery', () => <Grid />, {
     design: config({
@@ -86,19 +70,13 @@ storiesOf('Actions|FloatingButton', module)
   .add('light background', () => <Grid background="light" />)
   .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
-    <FloatingButton
-      small={boolean('Small', false)}
+    <FloatingIconButton
+      icon="list"
       secondary={boolean('Color override : Secondary', false)}
       warning={boolean('Color override : Warning', false)}
       disabled={boolean('Disabled', false)}
-      position={select('Position', positions, 'bottom')}
-      elementLeft={
-        boolean('Icon left', false) ? <Icon icon="list" /> : undefined
-      }
-      elementRight={
-        boolean('Icon right', false) ? <Icon icon="list" /> : undefined
-      }
+      position={select('Position', positions, 'bottom-right')}
     >
       Liste
-    </FloatingButton>
+    </FloatingIconButton>
   ))

--- a/src/FloatingIconButton/FloatingIconButton.style.ts
+++ b/src/FloatingIconButton/FloatingIconButton.style.ts
@@ -5,25 +5,6 @@ import breakpoints from '../breakpoints'
 import palette from '../palette'
 import theme from '../theme'
 
-export const SideElementContainer = styled.div`
-  font-size: 16px;
-  display: flex;
-  margin-top: -1px;
-
-  &[data-position='left'] {
-    margin-right: 8px;
-  }
-
-  &[data-position='right'] {
-    margin-left: 8px;
-  }
-`
-
-export const FloatingButtonContent = styled.div`
-  position: relative;
-  white-space: nowrap;
-`
-
 export const FloatingButtonContainer = styled.button`
   display: flex;
   justify-content: center;
@@ -34,21 +15,20 @@ export const FloatingButtonContainer = styled.button`
   vertical-align: middle;
   text-align: left;
   text-decoration: none;
-  box-shadow: ${theme.shadow('low')};
+  box-shadow: ${theme.shadow('lower')};
 
-  padding: 0 24px;
-  height: 40px;
-  border-radius: 20px;
-  max-width: 100%;
-  font-size: 12px;
-  line-height: 16px;
-  font-family: ${theme.font()};
-  text-transform: uppercase;
+  height: 48px;
+  width: 48px;
+  border-radius: 24px;
+  font-size: 24px;
 
   position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
+  bottom: 24px;
   z-index: ${zIndex.floatingButtons};
+
+  @media (${breakpoints.below.phone}) {
+    bottom: 12px;
+  }
 
   transition-property: border, padding, background-color;
   transition-duration: 50ms;
@@ -58,52 +38,35 @@ export const FloatingButtonContainer = styled.button`
     position: fixed;
   }
 
-  &[data-position='bottom'] {
-    bottom: 24px;
+  &[data-position='bottom-right'] {
+    right: 36px;
 
     @media (${breakpoints.below.phone}) {
-      bottom: 12px;
+      right: 18px;
     }
   }
 
-  &[data-position='top'] {
-    top: 24px;
+  &[data-position='bottom-left'] {
+    left: 36px;
 
     @media (${breakpoints.below.phone}) {
-      top: 12px;
-    }
-  }
-
-  &[data-small='true'] {
-    padding: 0 12px;
-    height: 28px;
-    border-radius: 14px;
-
-    & ${SideElementContainer} {
-      font-size: 12px;
+      left: 18px;
     }
   }
 
   border: 1px solid transparent;
   background-color: ${theme.color('primary', { dynamic: true })};
   color: ${theme.color('primary', {
-    variation: 'contrastText',
     dynamic: true,
+    variation: 'contrastText',
   })};
-
-  & svg {
-    fill: ${theme.color('primary', {
-      variation: 'contrastText',
-      dynamic: true,
-    })};
-  }
 
   &:hover {
     background-color: ${theme.color('primary', {
       dynamic: true,
       variation: 'hover',
     })};
-    box-shadow: ${theme.shadow('low', { hover: true })};
+    box-shadow: ${theme.shadow('lower', { hover: true })};
   }
 
   &:focus,

--- a/src/FloatingIconButton/FloatingIconButton.tsx
+++ b/src/FloatingIconButton/FloatingIconButton.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+
+import Icon from '../Icon'
+
+import FloatingButtonProps from './FloatingIconButton.interface'
+import { FloatingButtonContainer } from './FloatingIconButton.style'
+
+const FloatingIconButton = React.forwardRef<
+  HTMLButtonElement,
+  FloatingButtonProps
+>((props, ref) => {
+  const {
+    colored,
+    icon,
+    fixed = false,
+    position = 'bottom-right',
+    ...rest
+  } = props
+
+  return (
+    <FloatingButtonContainer
+      ref={ref}
+      {...rest}
+      data-fixed={fixed}
+      data-position={position}
+    >
+      <Icon icon={icon} colored={colored} />
+    </FloatingButtonContainer>
+  )
+})
+
+export default FloatingIconButton

--- a/src/FloatingIconButton/index.ts
+++ b/src/FloatingIconButton/index.ts
@@ -1,0 +1,5 @@
+import FloatingIconButton from './FloatingIconButton'
+
+export { default as FloatingIconButtonProps } from './FloatingIconButton.interface'
+
+export default FloatingIconButton

--- a/src/IconButton/IconButton.interface.ts
+++ b/src/IconButton/IconButton.interface.ts
@@ -1,0 +1,8 @@
+import { Button, styledAs } from '../_internal/types'
+import { IconProps } from '../Icon'
+
+export default interface IconButtonProps
+  extends Button,
+    Pick<IconProps, 'icon' | 'colored'> {
+  as?: styledAs
+}

--- a/src/IconButton/IconButton.stories.tsx
+++ b/src/IconButton/IconButton.stories.tsx
@@ -1,0 +1,76 @@
+import { withKnobs, boolean } from '@storybook/addon-knobs'
+import { storiesOf } from '@storybook/react'
+import * as React from 'react'
+import { config } from 'storybook-addon-designs'
+
+import withGrid from '../_internal/StorybookGrid'
+
+import IconButton from './IconButton'
+import IconButtonProps from './IconButton.interface'
+
+const GRID_PROPS = {
+  icon: 'zoom-in',
+}
+
+const GRID_LINES = [
+  {
+    title: 'Regular',
+  },
+  {
+    title: 'Small',
+    props: { small: true },
+  },
+  {
+    title: 'Large',
+    props: { large: true },
+  },
+]
+
+const GRID_ITEMS = [
+  {
+    label: 'Default',
+  },
+  {
+    label: 'Primary',
+    props: { primary: true },
+  },
+  {
+    label: 'Disabled',
+    props: { disabled: true },
+  },
+  {
+    label: 'Warning',
+    props: {
+      warning: true,
+    },
+  },
+]
+
+const Grid = withGrid<IconButtonProps>({
+  props: GRID_PROPS,
+  lines: GRID_LINES,
+  items: GRID_ITEMS,
+  itemHorizontalSpace: 36,
+})(IconButton)
+
+storiesOf('Actions|IconButton', module)
+  .addDecorator(withKnobs)
+  .add('gallery', () => <Grid />, {
+    design: config({
+      type: 'figma',
+      url:
+        'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=18%3A1250',
+    }),
+  })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
+  .add('dynamic', () => (
+    <IconButton
+      icon="list"
+      small={boolean('Small', false)}
+      large={boolean('Large', false)}
+      primary={boolean('Color override : Primary', false)}
+      secondary={boolean('Color override : Secondary', false)}
+      warning={boolean('Color override : Warning', false)}
+    />
+  ))

--- a/src/IconButton/IconButton.style.ts
+++ b/src/IconButton/IconButton.style.ts
@@ -1,0 +1,45 @@
+import styled from 'styled-components'
+
+import palette from '../palette'
+import theme from '../theme'
+
+export const IconButtonContainer = styled.button`
+  background: none;
+  border: none;
+  outline: none;
+  cursor: pointer;
+  padding: 0;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${theme.color('secondary', { dynamic: true })};
+
+  font-size: var(--icon-button-size);
+  width: var(--icon-button-size);
+  height: var(--icon-button-size);
+
+  --icon-button-size: 24px;
+
+  &[data-small='true'] {
+    --icon-button-size: 16px;
+  }
+
+  &[data-large='true'] {
+    --icon-button-size: 32px;
+  }
+
+  &:disabled {
+    pointer-events: none;
+    color: ${palette.darkBlue[400]};
+  }
+
+  &:hover {
+    color: ${theme.color('secondary', { dynamic: true, variation: 'hover' })};
+  }
+
+  &:focus,
+  &:active {
+    color: ${theme.color('secondary', { dynamic: true, variation: 'focus' })};
+  }
+`

--- a/src/IconButton/IconButton.tsx
+++ b/src/IconButton/IconButton.tsx
@@ -1,0 +1,25 @@
+import * as React from 'react'
+
+import Icon from '../Icon'
+
+import IconButtonProps from './IconButton.interface'
+import { IconButtonContainer } from './IconButton.style'
+
+const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
+  (props, ref) => {
+    const { icon, colored, small = false, large = false, ...rest } = props
+
+    return (
+      <IconButtonContainer
+        {...rest}
+        ref={ref}
+        data-small={small}
+        data-large={large}
+      >
+        <Icon icon={icon} colored={colored} />
+      </IconButtonContainer>
+    )
+  }
+)
+
+export default IconButton

--- a/src/IconButton/index.ts
+++ b/src/IconButton/index.ts
@@ -1,0 +1,5 @@
+import IconButton from './IconButton'
+
+export { default as IconButtonProps } from './IconButton.interface'
+
+export default IconButton

--- a/src/Loader/Loader.stories.tsx
+++ b/src/Loader/Loader.stories.tsx
@@ -28,11 +28,6 @@ const GRID_LINES = [
     title: 'Grey',
     props: { colored: false },
   },
-  {
-    title: 'Color background',
-    coloredBackground: true,
-    props: { outline: true, colored: false },
-  },
 ]
 
 const GRID_ITEMS = [
@@ -67,6 +62,8 @@ storiesOf('Miscellaneous|Loader', module)
         'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=18%3A1845',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <LoaderContainer>
       <Loader

--- a/src/Modal/Modal.stories.tsx
+++ b/src/Modal/Modal.stories.tsx
@@ -80,6 +80,7 @@ const Grid = withGrid<ModalProps>({
   props: GRID_PROPS,
   lines: GRID_LINES,
   items: GRID_ITEMS,
+  itemHorizontalSpace: 36,
 })(Modal)
 
 storiesOf('Modals|Modal', module).add('galery', () => <Grid />, {

--- a/src/Modal/Modal.style.ts
+++ b/src/Modal/Modal.style.ts
@@ -38,6 +38,9 @@ export const ModalContainer = styled(Background)`
     max-width: calc(100vw - 48px);
     max-height: calc(100vh - 96px);
     border-radius: 2px;
+
+    --modal-horizontal-padding: 36px;
+    --modal-vertical-padding: 48px;
   }
 
   @media (${breakpoints.below.phone}) {
@@ -46,6 +49,9 @@ export const ModalContainer = styled(Background)`
     bottom: 0;
     left: 0;
     right: 0;
+
+    --modal-horizontal-padding: 24px;
+    --modal-vertical-padding: 24px;
   }
 `
 
@@ -108,13 +114,12 @@ export const HeaderBarContainer = styled.div`
   align-items: center;
   justify-content: space-between;
   flex: 0 0 auto;
+  padding-left: var(--modal-horizontal-padding);
+  padding-right: var(--modal-horizontal-padding);
 
   &[data-has-title='true'] {
-    padding: 48px 36px 24px 36px;
-
-    @media (${breakpoints.below.phone}) {
-      padding: 16px 24px;
-    }
+    padding-top: var(--modal-vertical-padding);
+    padding-bottom: 12px;
   }
 `
 
@@ -160,19 +165,12 @@ export const ModalScrollableContent = styled.div`
   flex: 1;
   display: flex;
   flex-direction: column;
-  padding: 48px 36px;
   overflow-y: auto;
   overflow-x: hidden;
 
+  padding: var(--modal-vertical-padding) var(--modal-horizontal-padding);
+
   &[data-has-title='true'] {
-    padding-top: 24px;
-  }
-
-  @media (${breakpoints.below.phone}) {
-    padding: 36px 24px;
-
-    &[data-has-title='true'] {
-      padding-top: 6px;
-    }
+    padding-top: 12px;
   }
 `

--- a/src/NavigationButton/NavigationButton.stories.tsx
+++ b/src/NavigationButton/NavigationButton.stories.tsx
@@ -32,10 +32,6 @@ const GRID_LINES = [
     title: 'Toggle small',
     props: { usage: 'toggle' as 'toggle', small: true },
   },
-  {
-    title: 'Regular + Colored background',
-    coloredBackground: true,
-  },
 ]
 
 const GRID_ITEMS = [
@@ -71,6 +67,8 @@ storiesOf('Navigation|NavigationButton', module)
         'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=18%3A2116',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <NavigationButton
       disabled={boolean('Disabled', false)}

--- a/src/NavigationButton/NavigationButton.style.ts
+++ b/src/NavigationButton/NavigationButton.style.ts
@@ -34,15 +34,16 @@ export const NavigationButtonContainer = styled.button`
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: ${theme.color('background')};
   border: none;
   border-radius: 50%;
   z-index: 1;
   opacity: 1;
-  color: ${theme.color('primary', { dynamic: true })};
   box-shadow: ${theme.shadow('low')};
   transition: all 150ms ease-in-out;
   padding: 0;
+
+  color: ${theme.color('primary', { dynamic: true })};
+  background-color: ${theme.color('background')};
 
   &[data-large='true'] {
     ${size('l')};
@@ -82,8 +83,12 @@ export const NavigationButtonContainer = styled.button`
 
   &:disabled {
     color: ${palette.darkBlue[400]};
+  }
 
-    &[data-background='true'] {
+  &[data-background='true'] {
+    color: #fff;
+
+    &:disabled {
       color: ${theme.color('secondary', { opacity: 0.3, useRootTheme: true })};
     }
   }

--- a/src/NavigationButton/NavigationButton.tsx
+++ b/src/NavigationButton/NavigationButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 
+import useHasColoredBackground from '../_internal/useHasColoredBackground'
 import Icon from '../Icon'
-import useTheme from '../useTheme'
 
 import NavigationButtonProps from './NavigationButton.interface'
 import { NavigationButtonContainer } from './NavigationButton.style'
@@ -26,16 +26,22 @@ const NavigationButton = React.forwardRef<
   HTMLButtonElement,
   NavigationButtonProps
 >((props, ref) => {
-  const { previous, large, small, usage = 'navigation', ...rest } = props
+  const {
+    previous = false,
+    large = false,
+    small = false,
+    usage = 'navigation',
+    ...rest
+  } = props
 
-  const theme = useTheme()
+  const hasBackground = useHasColoredBackground()
 
   return (
     <NavigationButtonContainer
       ref={ref}
       data-large={large}
       data-small={small}
-      data-background={theme.backgroundColor !== '#FFFFFF'}
+      data-background={hasBackground}
       data-usage={usage}
       {...rest}
     >

--- a/src/NavigationDots/NavigationDots.interface.ts
+++ b/src/NavigationDots/NavigationDots.interface.ts
@@ -5,7 +5,6 @@ export default interface NavigationDotsProps
   size: number
   activeDot?: number
   disabled?: boolean
-  secondary?: boolean
   onClickDot?: (activeDot: number) => void
 }
 

--- a/src/NavigationDots/NavigationDots.stories.tsx
+++ b/src/NavigationDots/NavigationDots.stories.tsx
@@ -19,10 +19,6 @@ const GRID_LINES = [
   {
     title: 'Regular',
   },
-  {
-    title: 'Colored background',
-    coloredBackground: true,
-  },
 ]
 
 const GRID_ITEMS = [
@@ -56,12 +52,6 @@ const GRID_ITEMS = [
       disabled: true,
     },
   },
-  {
-    label: 'Secondary',
-    props: {
-      secondary: true,
-    },
-  },
 ]
 
 const Grid = withGrid<NavigationDotsProps>({
@@ -80,6 +70,8 @@ storiesOf('Navigation|NavigationDots', module)
         'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=18%3A2116',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <NavigationDots
       size={number('Size', 3)}

--- a/src/NavigationDots/NavigationDots.style.ts
+++ b/src/NavigationDots/NavigationDots.style.ts
@@ -16,19 +16,23 @@ export const Dot = styled.div<{ secondary?: boolean }>`
   border-radius: 4px;
   min-width: 8px;
   height: 8px;
-  background-color: ${palette.darkBlue[400]};
+  background-color: var(--navigation-dot-empty-color);
   vertical-align: middle;
   transition: all 300ms ease-in-out;
 
+  --navigation-dot-empty-color: ${palette.darkBlue[400]};
+  --navigation-dot-active-color: ${theme.color('primary')};
+
   &[data-background='true'] {
-    background-color: rgba(255, 255, 255, 0.3);
+    --navigation-dot-empty-color: rgba(255, 255, 255, 0.3);
+    --navigation-dot-active-color: #fff;
   }
 
   &[data-active='true'] {
     flex: 0 1 100%;
 
     &:not([data-disabled='true']) {
-      background-color: ${theme.color('primary', { dynamic: true })};
+      background-color: var(--navigation-dot-active-color);
     }
   }
 

--- a/src/NavigationDots/NavigationDots.tsx
+++ b/src/NavigationDots/NavigationDots.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import useTheme from '../useTheme'
+import useHasColoredBackground from '../_internal/useHasColoredBackground'
 
 import NavigationDotsProps, { DotObject } from './NavigationDots.interface'
 import { NavigationDotsContainer, Dot } from './NavigationDots.style'
@@ -9,16 +9,9 @@ const MAX_VISIBLE_DOTS = 5
 
 const NavigationDots = React.forwardRef<HTMLDivElement, NavigationDotsProps>(
   (props, ref) => {
-    const {
-      size,
-      disabled,
-      activeDot = 0,
-      onClickDot,
-      secondary,
-      ...rest
-    } = props
+    const { size, disabled, activeDot = 0, onClickDot, ...rest } = props
 
-    const theme = useTheme()
+    const hasBackground = useHasColoredBackground()
 
     const visibleDots = React.useMemo<DotObject[]>(() => {
       if (size < MAX_VISIBLE_DOTS) {
@@ -69,11 +62,10 @@ const NavigationDots = React.forwardRef<HTMLDivElement, NavigationDotsProps>(
             key={dot.index}
             data-active={!!dot.active}
             data-interactive={!!onClickDot}
-            data-background={theme.backgroundColor !== '#FFFFFF'}
+            data-background={hasBackground}
             data-small={dot.small}
             data-disabled={disabled}
             onClick={onClickDot ? () => onClickDot(dot.index) : undefined}
-            secondary={secondary}
           />
         ))}
       </NavigationDotsContainer>

--- a/src/Notification/Notification.style.ts
+++ b/src/Notification/Notification.style.ts
@@ -3,10 +3,7 @@ import styled from 'styled-components'
 import palette from '../palette'
 import theme from '../theme'
 
-export const NotificationContainer = styled.div<{
-  warning?: boolean
-  error?: boolean
-}>`
+export const NotificationContainer = styled.div`
   background-color: ${palette.darkBlue[100]};
   border-radius: 4px;
   display: flex;

--- a/src/PasswordInput/PasswordInput.stories.tsx
+++ b/src/PasswordInput/PasswordInput.stories.tsx
@@ -28,10 +28,6 @@ const GRID_LINES = [
     title: 'Small',
     props: { small: true },
   },
-  {
-    title: 'Colored background',
-    coloredBackground: true,
-  },
 ]
 
 const GRID_ITEMS = [
@@ -75,6 +71,8 @@ storiesOf('Input|PasswordInput', module)
         'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=18%3A1845',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <PasswordInputContainer>
       <PasswordInput

--- a/src/PasswordInput/PasswordInput.style.ts
+++ b/src/PasswordInput/PasswordInput.style.ts
@@ -23,7 +23,7 @@ export const HideButton = styled.div`
   line-height: inherit;
   vertical-align: bottom;
   height: 24px;
-  color: ${theme.textColor('disabledPlaceholder')};
+  color: ${theme.textColor({ useRootTheme: true })};
 
   &[data-active='true'] {
     color: ${theme.color('primary')};

--- a/src/PhoneInput/PhoneInput.stories.tsx
+++ b/src/PhoneInput/PhoneInput.stories.tsx
@@ -28,10 +28,6 @@ const GRID_LINES = [
     title: 'Small',
     props: { small: true },
   },
-  {
-    title: 'Colored background',
-    coloredBackground: true,
-  },
 ]
 
 const GRID_ITEMS = [
@@ -75,6 +71,8 @@ storiesOf('Input|PhoneInput', module)
         'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=18%3A1845',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <PhoneInputContainer>
       <PhoneInput

--- a/src/PhoneInput/PhoneInput.style.ts
+++ b/src/PhoneInput/PhoneInput.style.ts
@@ -17,7 +17,7 @@ export const CountryOptions = styled.div`
   user-select: none;
   width: 110px;
   background-color: ${palette.darkBlue[200]};
-  color: ${theme.textColor('placeholder')};
+  color: ${theme.textColor({ useRootTheme: true })};
   font-family: ${theme.font()};
   display: flex;
   justify-content: space-evenly;
@@ -32,8 +32,8 @@ export const PhoneInputContainer = styled.div`
   max-width: 100%;
   overflow: hidden;
   transition: all 150ms ease-in-out;
-  max-height: 3rem;
-  min-height: 3rem;
+  max-height: 48px;
+  min-height: 48px;
 
   outline: none;
   -moz-appearance: none;
@@ -70,7 +70,7 @@ export const PhoneInputContainer = styled.div`
 
     & ${CountryOptions} {
       border-right-color: #d0e4e6;
-      color: ${theme.textColor('disabledPlaceholder')};
+      color: ${theme.textColor({ useRootTheme: true })};
 
       & svg {
         filter: grayscale();
@@ -80,8 +80,8 @@ export const PhoneInputContainer = styled.div`
   }
 
   &[data-small='true'] {
-    min-height: 2.3rem;
-    max-height: 2.3rem;
+    min-height: 36px;
+    max-height: 36px;
   }
 
   &:focus-within {

--- a/src/PhoneInput/PhoneInput.tsx
+++ b/src/PhoneInput/PhoneInput.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
 
 import { useSSRLayoutEffect } from '../_internal/ssr'
+import useHasColoredBackground from '../_internal/useHasColoredBackground'
 import Icon from '../Icon'
-import useTheme from '../useTheme'
 
 import PhoneInputProps from './PhoneInput.interface'
 import {
@@ -41,7 +41,7 @@ const PhoneInput = React.forwardRef<HTMLInputElement, PhoneInputProps>(
     } = props
 
     const [country, setCountry] = React.useState<string>('fr')
-    const theme = useTheme()
+    const hasBackground = useHasColoredBackground()
 
     const { indicator, flag: Flag } = React.useMemo<COUNTRY>(
       () => COUNTRIES.find(({ code }) => code === country) as COUNTRY,
@@ -100,7 +100,7 @@ const PhoneInput = React.forwardRef<HTMLInputElement, PhoneInputProps>(
         data-error={error}
         data-disabled={disabled}
         data-small={small}
-        data-background={theme.backgroundColor !== '#FFFFFF'}
+        data-background={hasBackground}
       >
         <CountryOptions>
           <FlagContainer>

--- a/src/Select/Select.stories.tsx
+++ b/src/Select/Select.stories.tsx
@@ -46,10 +46,6 @@ const GRID_LINES = [
       light: true,
     },
   },
-  {
-    title: 'Colored background',
-    coloredBackground: true,
-  },
 ]
 
 const GRID_ITEMS = [
@@ -101,6 +97,8 @@ storiesOf('Input|Select', module)
         'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=18%3A1846',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <TextInputContainer>
       <Select

--- a/src/Select/Select.style.ts
+++ b/src/Select/Select.style.ts
@@ -12,10 +12,10 @@ export const Placeholder = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   transition: color 150ms ease-in-out;
-  color: ${theme.textColor('base')};
+  color: ${theme.textColor({ useRootTheme: true })};
 
   &[data-empty='true'] {
-    color: ${theme.textColor('placeholder')};
+    color: ${theme.textColor({ opacity: 0.6, useRootTheme: true })};
   }
 `
 
@@ -24,7 +24,7 @@ export const LabelIcons = styled.div`
   display: flex;
   align-items: center;
   height: 100%;
-  color: ${theme.textColor('placeholder')};
+  color: ${theme.textColor({ opacity: 0.6, useRootTheme: true })};
 
   span {
     font-size: 18px;
@@ -40,8 +40,8 @@ export const SelectContent = styled.div`
   cursor: pointer;
 
   z-index: 0;
-  padding: 12px 16px;
-  height: 48px;
+  padding: 11px 16px;
+  height: 45px;
   line-height: 24px;
 
   font-size: ${theme.font('text')};
@@ -53,8 +53,8 @@ export const SelectContent = styled.div`
   }
 
   &[data-small='true'] {
-    padding: 7px 12px;
-    height: 38px;
+    padding: 5.5px 12px;
+    height: 35px;
   }
 `
 
@@ -69,7 +69,7 @@ export const SelectContainer = styled.div`
   border-radius: 4px;
 
   &:not([data-light='true']) {
-    color: ${theme.textColor('base')};
+    color: ${theme.textColor({ useRootTheme: true })};
     background-color: ${palette.darkBlue[200]};
     border: solid 1.5px ${palette.darkBlue[200]};
   }
@@ -108,7 +108,7 @@ export const SelectContainer = styled.div`
 
     &::placeholder,
     ${Placeholder} {
-      color: ${theme.textColor('disabledPlaceholder')};
+      color: ${theme.textColor({ opacity: 0.4, useRootTheme: true })};
     }
   }
 
@@ -118,7 +118,7 @@ export const SelectContainer = styled.div`
     border-color: ${palette.darkBlue[300]};
 
     & ${LabelIcons} {
-      color: ${theme.color('secondary')};
+      color: ${theme.textColor({ useRootTheme: true })};
     }
   }
 

--- a/src/Select/Select.tsx
+++ b/src/Select/Select.tsx
@@ -5,9 +5,9 @@ import { createPortal } from 'react-dom'
 import { isNil, has } from '../_internal/data'
 import { isClientSide, getDOMRect } from '../_internal/ssr'
 import { formOption } from '../_internal/types'
+import useHasColoredBackground from '../_internal/useHasColoredBackground'
 import useMergedRef from '../_internal/useMergedRef'
 import Icon from '../Icon'
-import useTheme from '../useTheme'
 
 import Options from './Options'
 import {
@@ -65,7 +65,7 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>(
 
     const inputRef = React.useRef<HTMLInputElement>(null)
     const wrapperRef = useMergedRef<HTMLDivElement>(ref)
-    const theme = useTheme()
+    const hasBackground = useHasColoredBackground()
 
     const reducer: React.Reducer<SelectState, SelectAction> = (
       state,
@@ -342,7 +342,7 @@ const Select = React.forwardRef<HTMLDivElement, SelectProps>(
         ref={wrapperRef}
         data-disabled={disabled}
         data-open={state.isOpened}
-        data-background={theme.backgroundColor !== '#FFFFFF'}
+        data-background={hasBackground}
         data-light={light}
         {...rest}
       >

--- a/src/SlideShow/SlideShow.interface.ts
+++ b/src/SlideShow/SlideShow.interface.ts
@@ -21,7 +21,6 @@ export default interface SlideShowProps {
   ) => void
   hideNavigation?: boolean
   circular?: boolean
-  secondary?: boolean
   referenceSlideIndex?: number
   navigationComponent?: React.ComponentType<any>
   hideNavigationDots?: boolean

--- a/src/SlideShow/SlideShow.tsx
+++ b/src/SlideShow/SlideShow.tsx
@@ -26,7 +26,6 @@ const SlideShow = React.forwardRef<HTMLDivElement, SlideShowProps>(
       onSelectedSlideChange,
       registerActions,
       circular = true,
-      secondary,
       referenceSlideIndex = 0,
       ...rest
     } = props
@@ -101,7 +100,6 @@ const SlideShow = React.forwardRef<HTMLDivElement, SlideShowProps>(
           </SlideShowSlidingContent>
         </SlideShowSlidingContainer>
         <SlideShowNavigation
-          secondary={secondary}
           next={slideShow.handleNextClick}
           previous={slideShow.handlePreviousClick}
           active={slideShow.currentSlide}

--- a/src/SlideShow/SlideShowNavigation.tsx
+++ b/src/SlideShow/SlideShowNavigation.tsx
@@ -16,7 +16,6 @@ const SlideShowNavigation: React.FunctionComponent<SlideShowNavigationProps> = (
   circular,
   hideNavigationDots,
   navigationComponent,
-  secondary,
 }) => (
   <React.Fragment>
     <NavigationButtonContainer as={navigationComponent}>
@@ -25,7 +24,6 @@ const SlideShowNavigation: React.FunctionComponent<SlideShowNavigationProps> = (
         large
         onClick={previous}
         disabled={!circular && active === 0}
-        secondary={secondary}
       />
     </NavigationButtonContainer>
     <NavigationButtonContainer data-right as={navigationComponent}>
@@ -33,16 +31,11 @@ const SlideShowNavigation: React.FunctionComponent<SlideShowNavigationProps> = (
         large
         onClick={next}
         disabled={!circular && active === size - 1}
-        secondary={secondary}
       />
     </NavigationButtonContainer>
     {!hideNavigationDots && (
       <NavigationDotsContainer>
-        <NavigationDots
-          size={size}
-          activeDot={(active + size) % size}
-          secondary={secondary}
-        />
+        <NavigationDots size={size} activeDot={(active + size) % size} />
       </NavigationDotsContainer>
     )}
   </React.Fragment>
@@ -55,7 +48,6 @@ interface SlideShowNavigationProps {
   active: number
   hideNavigationDots: boolean
   circular: boolean
-  secondary?: boolean
   navigationComponent?: React.ComponentType<any>
 }
 

--- a/src/Slider/Slider.stories.tsx
+++ b/src/Slider/Slider.stories.tsx
@@ -119,3 +119,5 @@ storiesOf('Input|Slider', module)
         'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=60%3A6',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)

--- a/src/Slider/SliderDot/SliderDot.style.ts
+++ b/src/Slider/SliderDot/SliderDot.style.ts
@@ -11,7 +11,7 @@ export const SliderDotContent = styled.div`
   background-color: ${theme.color('primary', { dynamic: true })};
 
   &:hover {
-    box-shadow: ${theme.shadow('regular')};
+    box-shadow: ${theme.shadow('low', { hover: true })};
   }
 
   &:active {

--- a/src/Tab/Tab.stories.tsx
+++ b/src/Tab/Tab.stories.tsx
@@ -13,15 +13,7 @@ const GRID_PROPS = {
   children: 'Agencement 1',
 }
 
-const GRID_LINES = [
-  {
-    title: 'White background',
-  },
-  {
-    title: 'Colored background',
-    coloredBackground: true,
-  },
-]
+const GRID_LINES = [{}]
 
 const GRID_ITEMS = [
   {
@@ -68,6 +60,8 @@ storiesOf('Navigation|Tab', module)
         'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=1393%3A0',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <Tab
       children={text('Value', 'Agencement 1')}

--- a/src/Tab/Tab.style.ts
+++ b/src/Tab/Tab.style.ts
@@ -25,7 +25,7 @@ export const TabContainer = styled.button`
   padding: 0 12px;
   height: 28px;
   font-size: 12px;
-  color: ${theme.color('secondary', {
+  color: ${theme.textColor({
     opacity: 0.72,
   })};
 
@@ -69,11 +69,17 @@ export const TabContainer = styled.button`
       }
 
       &[data-background='true'] {
-        border-color: rgba(255, 255, 255, 0.3);
-        color: ${theme.color('secondary')};
+        border-color: #fff;
+        color: #fff;
 
         &:hover:not(:focus):not(:active) {
+          color: ${theme.textColor({ opacity: 0.72, useRootTheme: true })};
           background-color: rgba(255, 255, 255, 0.7);
+          border-color: transparent;
+        }
+
+        &:focus {
+          background-color: transparent;
         }
       }
     }
@@ -100,6 +106,7 @@ export const TabContainer = styled.button`
 
     &[data-background='true'] {
       background-color: #fff;
+      color: ${theme.textColor({ opacity: 0.72, useRootTheme: true })};
     }
   }
 `

--- a/src/Tab/Tab.tsx
+++ b/src/Tab/Tab.tsx
@@ -1,21 +1,28 @@
 import * as React from 'react'
 
-import useTheme from '../useTheme'
+import useHasColoredBackground from '../_internal/useHasColoredBackground'
 
 import TagProps from './Tab.interface'
 import { TabContainer, SideElementContainer } from './Tab.style'
 
 const Tab = React.forwardRef<HTMLButtonElement, TagProps>((props, ref) => {
-  const { large, active, elementLeft, elementRight, children, ...rest } = props
+  const {
+    large = false,
+    active = false,
+    elementLeft,
+    elementRight,
+    children,
+    ...rest
+  } = props
 
-  const theme = useTheme()
+  const hasBackground = useHasColoredBackground()
 
   return (
     <TabContainer
       ref={ref}
       data-large={large}
       data-active={active}
-      data-background={theme.backgroundColor !== '#FFFFFF'}
+      data-background={hasBackground}
       {...rest}
     >
       {elementLeft && (

--- a/src/Tag/Tag.stories.tsx
+++ b/src/Tag/Tag.stories.tsx
@@ -13,15 +13,7 @@ const GRID_PROPS = {
   children: 'Agencement 1',
 }
 
-const GRID_LINES = [
-  {
-    title: 'White background',
-  },
-  {
-    title: 'Colored background',
-    coloredBackground: true,
-  },
-]
+const GRID_LINES = [{}]
 
 const GRID_ITEMS = [
   {
@@ -64,6 +56,8 @@ storiesOf('Actions|Tag', module)
         'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=1475%3A0',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <Tag
       children={text('Value', 'Agencement 1')}

--- a/src/Tag/Tag.style.ts
+++ b/src/Tag/Tag.style.ts
@@ -51,8 +51,9 @@ export const TagContainer = styled.button`
       }
 
       &[data-background='true'] {
-        border-color: rgba(255, 255, 255, 0.3);
-        color: ${theme.color('secondary')};
+        color: ${theme.textColor({ opacity: 0.72, useRootTheme: true })};
+        background-color: #fff;
+        border-color: #fff;
 
         &:hover:not(:focus):not(:active) {
           background-color: rgba(255, 255, 255, 0.7);

--- a/src/Tag/Tag.tsx
+++ b/src/Tag/Tag.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 
-import useTheme from '../useTheme'
+import useHasColoredBackground from '../_internal/useHasColoredBackground'
 
 import TagProps from './Tag.interface'
 import { TagContainer, SideElementContainer } from './Tag.style'
@@ -8,13 +8,13 @@ import { TagContainer, SideElementContainer } from './Tag.style'
 const Tag = React.forwardRef<HTMLButtonElement, TagProps>((props, ref) => {
   const { active, elementLeft, elementRight, children, ...rest } = props
 
-  const theme = useTheme()
+  const hasBackground = useHasColoredBackground()
 
   return (
     <TagContainer
       ref={ref}
       data-active={active}
-      data-background={theme.backgroundColor !== '#FFFFFF'}
+      data-background={hasBackground}
       {...rest}
     >
       {elementLeft && (

--- a/src/Text/Text.stories.tsx
+++ b/src/Text/Text.stories.tsx
@@ -1,4 +1,10 @@
-import { withKnobs, select, boolean, text } from '@storybook/addon-knobs'
+import {
+  withKnobs,
+  select,
+  boolean,
+  text,
+  number,
+} from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 import { config } from 'storybook-addon-designs'
@@ -38,13 +44,6 @@ const GRID_LINES = [
     title: typeName,
     props: { type },
   })),
-  {
-    title: 'Colored background',
-    coloredBackground: true,
-    props: {
-      opacity: 1,
-    },
-  },
 ]
 
 const GRID_ITEMS = [{}]
@@ -70,6 +69,8 @@ storiesOf('Typography|Text', module)
         'https://www.figma.com/file/f5tJXjQSoOhy7K3r99pv21Fd/Brand-assets-%26-colors?node-id=8%3A2',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <TextContainer>
       <Text
@@ -82,6 +83,12 @@ storiesOf('Typography|Text', module)
         secondary={boolean('Color override : Secondary', false)}
         warning={boolean('Color override : Warning', false)}
         markdown={boolean('Markdown support', false)}
+        opacity={number('Opacity', 0.72, {
+          range: true,
+          min: 0,
+          max: 1,
+          step: 0.01,
+        })}
       />
     </TextContainer>
   ))

--- a/src/Text/Text.tsx
+++ b/src/Text/Text.tsx
@@ -18,6 +18,7 @@ const baseTextStyle = css<{ color?: string }>`
   color: ${theme.textColor({
     opacity: 0.72,
     dynamic: true,
+    propName: 'color',
   })};
 
   font-family: ${theme.font()};
@@ -58,7 +59,7 @@ const emphasisTextStyle = css<{ color?: string }>`
   ${size('mars')};
   font-weight: 500;
 
-  color: ${theme.textColor({ dynamic: true })};
+  color: ${theme.textColor({ dynamic: true, propName: 'color' })};
 `
 
 const regularTextStyle = css`

--- a/src/Text/Text.tsx
+++ b/src/Text/Text.tsx
@@ -15,10 +15,9 @@ const size = (name: keyof FontScale) => css`
 `
 
 const baseTextStyle = css<{ color?: string }>`
-  color: ${theme.color('secondary', {
-    dynamic: true,
-    propName: 'color',
+  color: ${theme.textColor({
     opacity: 0.72,
+    dynamic: true,
   })};
 
   font-family: ${theme.font()};
@@ -59,10 +58,7 @@ const emphasisTextStyle = css<{ color?: string }>`
   ${size('mars')};
   font-weight: 500;
 
-  color: ${theme.color('secondary', {
-    dynamic: true,
-    propName: 'color',
-  })};
+  color: ${theme.textColor({ dynamic: true })};
 `
 
 const regularTextStyle = css`

--- a/src/TextArea/TextArea.stories.tsx
+++ b/src/TextArea/TextArea.stories.tsx
@@ -28,10 +28,6 @@ const GRID_LINES = [
     title: 'Small',
     props: { small: true },
   },
-  {
-    title: 'Colored background',
-    coloredBackground: true,
-  },
 ]
 
 const GRID_ITEMS = [
@@ -75,6 +71,8 @@ storiesOf('Input|TextArea', module)
         'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=18%3A1845',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <TextAreaContainer>
       <TextArea

--- a/src/TextInput/TextInput.stories.tsx
+++ b/src/TextInput/TextInput.stories.tsx
@@ -32,10 +32,6 @@ const GRID_LINES = [
     title: 'Light',
     props: { light: true },
   },
-  {
-    title: 'Colored background',
-    coloredBackground: true,
-  },
 ]
 
 const GRID_ITEMS = [
@@ -85,6 +81,8 @@ storiesOf('Input|TextInput', module)
         'https://www.figma.com/file/LfGEUbovutcTpygwzrfTYbl5/Desktop-components?node-id=18%3A1845',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <TextInputContainer>
       <TextInput

--- a/src/TextInput/TextInput.style.ts
+++ b/src/TextInput/TextInput.style.ts
@@ -23,11 +23,11 @@ export const inputStyle = css`
 
   &:not([data-light='true']) {
     border-color: ${palette.darkBlue[200]};
-    color: ${theme.textColor('base')};
+    color: ${theme.textColor({ useRootTheme: true })};
     background-color: ${palette.darkBlue[200]};
 
     &::placeholder {
-      color: ${theme.textColor('placeholder')};
+      color: ${theme.textColor({ opacity: 0.6, useRootTheme: true })};
     }
 
     &:disabled {
@@ -36,7 +36,7 @@ export const inputStyle = css`
       pointer-events: none;
 
       &::placeholder {
-        color: ${theme.textColor('disabledPlaceholder')};
+        color: ${theme.textColor({ opacity: 0.4, useRootTheme: true })};
       }
     }
 
@@ -73,7 +73,7 @@ export const inputStyle = css`
 
     &:focus {
       border-color: ${palette.darkBlue[300]};
-      color: ${theme.color('secondary')};
+      color: ${theme.textColor({ useRootTheme: true })};
     }
   }
 
@@ -121,8 +121,8 @@ export const Input = styled.input`
   flex: 1;
   margin: 0;
   padding: 0 16px;
-  max-height: 3rem;
-  min-height: 3rem;
+  max-height: 48px;
+  min-height: 48px;
   max-width: 100%;
   min-width: 0;
   width: 100%;
@@ -130,13 +130,15 @@ export const Input = styled.input`
   &[data-padding-left='true'] {
     padding-left: 48px;
   }
+
   &:focus + ${LeftElementContainer} {
     color: ${theme.color('primary')};
   }
+
   &[data-small='true'] {
     padding: 0 12px;
-    min-height: 2.3rem;
-    max-height: 2.3rem;
+    min-height: 36px;
+    max-height: 36px;
   }
 
   ${inputStyle};
@@ -145,11 +147,11 @@ export const Input = styled.input`
 export const InputContainer = styled.div`
   position: relative;
   width: 100%;
-  color: ${theme.textColor('placeholder')};
+  color: ${theme.textColor({ useRootTheme: true })};
 
   &:hover,
   &:focus-within {
-    color: ${theme.color('secondary')};
+    color: ${theme.textColor({ useRootTheme: true })};
   }
 `
 

--- a/src/TextInput/TextInput.tsx
+++ b/src/TextInput/TextInput.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { ChangeEvent } from 'react'
 
 import { isFunction } from '../_internal/data'
-import useTheme from '../useTheme'
+import useHasColoredBackground from '../_internal/useHasColoredBackground'
 
 import TextInputProps from './TextInput.interface'
 import {
@@ -26,7 +26,8 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
       canReset,
       ...rest
     } = props
-    const theme = useTheme()
+
+    const hasBackground = useHasColoredBackground()
 
     return (
       <InputContainer className={className} style={style} data-error={error}>
@@ -35,7 +36,7 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputProps>(
           data-error={error}
           data-light={light}
           data-padding-left={!!elementLeft}
-          data-background={theme.backgroundColor !== '#FFFFFF'}
+          data-background={hasBackground}
           {...rest}
           ref={ref}
         />

--- a/src/ThemeProvider/ThemeProvider.interface.ts
+++ b/src/ThemeProvider/ThemeProvider.interface.ts
@@ -1,24 +1,17 @@
 import * as React from 'react'
 
-import {
-  ColorFamilies,
-  Fonts,
-  Shadows,
-  TextColorVariations,
-} from '../theme/theme.interface'
+import { ColorFamilies, Fonts, Shadows } from '../theme/theme.interface'
 
 export interface DesignSystemThemePatch {
   colors?: Partial<ColorFamilies>
-  textColors?: Partial<TextColorVariations>
   fonts?: Partial<Fonts>
   shadows?: Partial<Shadows>
   backgroundColor?: string
+  isDark?: boolean
 }
 
 export default interface ThemeProviderProps {
   theme?: DesignSystemThemePatch
-  themeFamily?: 'habx' | 'icade' | 'cogedim'
-  isRoot?: boolean
   backgroundColor?: string
   children?: React.ReactNode
 }

--- a/src/ThemeProvider/ThemeProvider.tsx
+++ b/src/ThemeProvider/ThemeProvider.tsx
@@ -77,7 +77,11 @@ const ThemeProvider: React.FunctionComponent<ThemeProviderProps> = ({
       }
     }
 
-    return styledTheme
+    return {
+      ...styledTheme,
+      uiCore: currentTheme,
+      uiCoreRoot: currentThemeRoot,
+    }
   }, [backgroundColor, currentTheme, currentThemeRoot, styledTheme, theme])
 
   return (

--- a/src/Title/Title.stories.tsx
+++ b/src/Title/Title.stories.tsx
@@ -1,4 +1,10 @@
-import { withKnobs, select, boolean, text } from '@storybook/addon-knobs'
+import {
+  withKnobs,
+  select,
+  boolean,
+  text,
+  number,
+} from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 import { config } from 'storybook-addon-designs'
@@ -45,13 +51,6 @@ const GRID_LINES = [
       type: type,
     },
   })),
-  {
-    title: 'Colored background',
-    props: {
-      type: 'article' as TitleTypes,
-    },
-    coloredBackground: true,
-  },
 ]
 
 const GRID_ITEMS = [{}]
@@ -71,6 +70,8 @@ storiesOf('Typography|Title', module)
         'https://www.figma.com/file/f5tJXjQSoOhy7K3r99pv21Fd/Brand-assets-%26-colors?node-id=8%3A2',
     }),
   })
+  .add('light background', () => <Grid background="light" />)
+  .add('dark background', () => <Grid background="dark" />)
   .add('dynamic', () => (
     <TitleContainer>
       <Title
@@ -83,6 +84,12 @@ storiesOf('Typography|Title', module)
         secondary={boolean('Color override : Secondary', false)}
         warning={boolean('Color override : Warning', false)}
         markdown={boolean('Markdown support', false)}
+        opacity={number('Opacity', 1, {
+          range: true,
+          min: 0,
+          max: 1,
+          step: 0.01,
+        })}
       />
     </TitleContainer>
   ))

--- a/src/Title/Title.tsx
+++ b/src/Title/Title.tsx
@@ -14,7 +14,7 @@ const size = (name: keyof FontScale) => css`
 `
 
 const baseTitleStyle = css<{ color?: string }>`
-  color: ${theme.textColor({ dynamic: true })};
+  color: ${theme.textColor({ dynamic: true, propName: 'color' })};
   font-family: ${theme.font('title')};
   font-weight: 400;
   margin: 0;

--- a/src/Title/Title.tsx
+++ b/src/Title/Title.tsx
@@ -14,7 +14,7 @@ const size = (name: keyof FontScale) => css`
 `
 
 const baseTitleStyle = css<{ color?: string }>`
-  color: ${theme.color('secondary', { dynamic: true, propName: 'color' })};
+  color: ${theme.textColor({ dynamic: true })};
   font-family: ${theme.font('title')};
   font-weight: 400;
   margin: 0;

--- a/src/_internal/StorybookGrid.tsx
+++ b/src/_internal/StorybookGrid.tsx
@@ -6,9 +6,20 @@ import palette from '../palette'
 import Text from '../Text'
 import Title from '../Title'
 
-const StorybookGridContainer = styled.div`
-  margin: 64px;
+const StorybookGridContainer = styled(Background)`
+  width: 100vw;
+  height: 100%;
+  min-height: 100vh;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 24px 36px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 `
+
+const StorybookGridContent = styled.div``
 
 const LineContainer = styled.div`
   padding: 24px 36px;
@@ -38,9 +49,8 @@ const Label = styled(Text)`
 `
 
 type GridLine<Props> = {
-  title: React.ReactNode
+  title?: React.ReactNode
   props?: Partial<Props>
-  coloredBackground?: boolean
 }
 
 type GridItem<Props> = {
@@ -55,6 +65,7 @@ interface StorybookGridConfig<Props> {
   itemHorizontalSpace?: number
   itemVerticalSpace?: number
   itemWrapper?: React.ComponentType<any>
+  showBackgroundVariations?: boolean
 }
 
 const withGrid = <Props extends object>(config: StorybookGridConfig<Props>) => (
@@ -65,50 +76,70 @@ const withGrid = <Props extends object>(config: StorybookGridConfig<Props>) => (
     lines,
     items,
     itemWrapper: ItemWrapper = React.Fragment,
-    itemHorizontalSpace = 8,
-    itemVerticalSpace = 8,
+    itemHorizontalSpace = 18,
+    itemVerticalSpace = 12,
   } = config
 
-  const Component: React.FunctionComponent<{}> = () => (
-    <StorybookGridContainer>
-      {lines.map((line, lineIndex) => {
-        const content = (
-          <LineContainer>
-            <Title type="section">{line.title}</Title>
-            <LineContent>
-              {items.map(item => {
-                const fullProps = {
-                  ...props,
-                  ...line.props,
-                  ...item.props,
-                } as Props
+  const Component: React.FunctionComponent<{
+    background?: 'light' | 'dark' | 'none'
+  }> = ({ background = 'none' }) => {
+    const backgroundColor = React.useMemo(() => {
+      switch (background) {
+        case 'dark': {
+          return palette.darkBlue[900]
+        }
 
-                return (
-                  <ItemContainer
-                    itemHorizontalSpace={itemHorizontalSpace}
-                    itemVerticalSpace={itemVerticalSpace}
-                  >
-                    <ItemWrapper>
-                      <WrappedComponent {...fullProps} />
-                    </ItemWrapper>
-                    {item.label && <Label opacity={1}>{item.label} </Label>}
-                  </ItemContainer>
-                )
-              })}
-            </LineContent>
-          </LineContainer>
-        )
+        case 'light': {
+          return palette.blue[300]
+        }
 
-        return line.coloredBackground ? (
-          <Background backgroundColor={palette.green[600]} key={lineIndex}>
-            {content}
-          </Background>
-        ) : (
-          <React.Fragment key={lineIndex}>{content}</React.Fragment>
-        )
-      })}
-    </StorybookGridContainer>
-  )
+        case 'none': {
+          return '#FFFFFF'
+        }
+
+        default: {
+          return '#FFFFFF'
+        }
+      }
+    }, [background])
+
+    return (
+      <StorybookGridContainer backgroundColor={backgroundColor}>
+        <StorybookGridContent>
+          {lines.map((line, lineIndex) => {
+            const content = (
+              <LineContainer>
+                <Title type="section">{line.title}</Title>
+                <LineContent>
+                  {items.map(item => {
+                    const fullProps = {
+                      ...props,
+                      ...line.props,
+                      ...item.props,
+                    } as Props
+
+                    return (
+                      <ItemContainer
+                        itemHorizontalSpace={itemHorizontalSpace}
+                        itemVerticalSpace={itemVerticalSpace}
+                      >
+                        <ItemWrapper>
+                          <WrappedComponent {...fullProps} />
+                        </ItemWrapper>
+                        {item.label && <Label opacity={1}>{item.label} </Label>}
+                      </ItemContainer>
+                    )
+                  })}
+                </LineContent>
+              </LineContainer>
+            )
+
+            return <React.Fragment key={lineIndex}>{content}</React.Fragment>
+          })}
+        </StorybookGridContent>
+      </StorybookGridContainer>
+    )
+  }
 
   return Component
 }

--- a/src/_internal/color.ts
+++ b/src/_internal/color.ts
@@ -1,0 +1,11 @@
+export const parseHexColor = (hex: string): [number, number, number] => [
+  parseInt(hex.slice(1, 3), 16),
+  parseInt(hex.slice(3, 5), 16),
+  parseInt(hex.slice(5, 7), 16),
+]
+
+export const isColorDark = (hex: string): boolean => {
+  const rgb = parseHexColor(hex)
+
+  return rgb[0] + rgb[1] + rgb[2] < (255 * 3) / 2
+}

--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -23,9 +23,9 @@ export interface Button
   large?: boolean
 }
 
-export interface styledTheme {
-  designSystem: DesignSystemTheme
-  designSystemRoot: DesignSystemTheme
+export interface StyledTheme {
+  uiCore: DesignSystemTheme
+  uiCoreRoot: DesignSystemTheme
 }
 
 export type formOption = { value: any; label: string }

--- a/src/_internal/useHasColoredBackground.ts
+++ b/src/_internal/useHasColoredBackground.ts
@@ -1,0 +1,9 @@
+import useTheme from '../useTheme'
+
+const useHasColoredBackground = () => {
+  const theme = useTheme()
+
+  return theme.backgroundColor !== '#FFFFFF'
+}
+
+export default useHasColoredBackground

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-/* eslint-disable */
+/* eslint-disable prettier/prettier */
 
 /*
   Providers
@@ -14,19 +14,18 @@ export { default as Title, TitleProps, titleStyles } from './Title'
 export { default as Link, LinkProps, linkStyle } from './Link'
 
 /*
-  Menu
- */
-export { default as Menu, MenuProps } from './Menu'
-export { default as MenuSection, MenuSectionProps } from './MenuSection'
-export { default as MenuLine, MenuLineProps } from './MenuLine'
-
-/*
   Buttons / Tags
  */
 export { default as Button, ButtonProps } from './Button'
 export { default as FloatingButton, FloatingButtonProps } from './FloatingButton'
+export { default as FloatingIconButton, FloatingIconButtonProps } from './FloatingIconButton'
+export { default as IconButton, IconButtonProps } from './IconButton'
 export { default as NavigationButton, NavigationButtonProps } from './NavigationButton'
 export { default as Tag, TagProps } from './Tag'
+
+/*
+  Navigation
+ */
 export { default as NavBar,  NavBarProps } from './NavBar'
 export { default as NavBarItem,  NavBarItemProps } from './NavBarItem'
 export { default as NavBarMenuItem,  NavBarMenuItemProps } from './NavBarMenuItem'

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,13 @@ export { default as Title, TitleProps, titleStyles } from './Title'
 export { default as Link, LinkProps, linkStyle } from './Link'
 
 /*
+  Menu
+ */
+export { default as Menu, MenuProps } from './Menu'
+export { default as MenuSection, MenuSectionProps } from './MenuSection'
+export { default as MenuLine, MenuLineProps } from './MenuLine'
+
+/*
   Buttons / Tags
  */
 export { default as Button, ButtonProps } from './Button'
@@ -41,6 +48,7 @@ export { default as Select, SelectProps } from './Select'
 export { default as Slider, SliderProps } from './Slider'
 export { default as TextArea, TextAreaProps } from './TextArea'
 export { default as TextInput, TextInputProps } from './TextInput'
+
 
 /*
   Miscellaneous

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,6 +1,6 @@
 import theme from './theme'
 
-export { BASE_THEME, THEME_PATCHES, FAMILY_PATCHES } from './theme.data'
+export { BASE_THEME, PATCH_WHITE } from './theme.data'
 export { default as DesignSystemTheme } from './theme.interface'
 
 export default theme

--- a/src/theme/theme.data.ts
+++ b/src/theme/theme.data.ts
@@ -1,5 +1,4 @@
 import palette from '../palette'
-import { DesignSystemThemePatch } from '../ThemeProvider'
 
 import DesignSystemTheme, { ColorVariations } from './theme.interface'
 
@@ -27,14 +26,9 @@ export const BASE_THEME: DesignSystemTheme = {
     },
   },
 
-  textColors: {
-    base: palette.darkBlue[900],
-    title: palette.darkBlue[900],
-    placeholder: palette.darkBlue[700],
-    disabledPlaceholder: palette.darkBlue[400],
-  },
-
   backgroundColor: WHITE,
+  textColor: palette.darkBlue[900],
+  isDark: false,
 
   fonts: {
     title: 'EuclidCircularB, sans-serif',
@@ -63,75 +57,9 @@ export const BASE_THEME: DesignSystemTheme = {
   },
 }
 
-const PATCH_WHITE: ColorVariations = {
+export const PATCH_WHITE: ColorVariations = {
   base: WHITE,
   hover: palette.darkBlue[200],
   focus: palette.darkBlue[400],
   contrastText: palette.darkBlue[900],
-}
-
-export const THEME_PATCHES: { [key: string]: DesignSystemThemePatch } = {
-  [palette.darkBlue[900]]: {
-    colors: {
-      secondary: PATCH_WHITE,
-    },
-  },
-  [palette.darkBlue[700]]: {
-    colors: {
-      secondary: PATCH_WHITE,
-    },
-  },
-  [palette.blue[800]]: {
-    colors: {
-      secondary: PATCH_WHITE,
-    },
-  },
-  [palette.blue[600]]: {
-    colors: {
-      secondary: PATCH_WHITE,
-    },
-  },
-  [palette.green[600]]: {
-    colors: {
-      primary: PATCH_WHITE,
-      secondary: {
-        base: palette.orange[300],
-        hover: palette.orange[300],
-        focus: palette.orange[300],
-        contrastText: WHITE,
-      },
-    },
-  },
-}
-
-export const FAMILY_PATCHES: { [key: string]: DesignSystemThemePatch } = {
-  habx: {},
-  icade: {
-    colors: {
-      primary: {
-        base: '#00B1E5',
-        hover: '#0097C3',
-        focus: '#007CA1',
-        contrastText: '#FFFFFF',
-      },
-      secondary: {
-        base: '#363636',
-        hover: '#474747',
-        focus: '#585858',
-      },
-    },
-    textColors: {
-      base: '#363636',
-      title: '#363636',
-    },
-  },
-  cogedim: {
-    colors: {
-      primary: {
-        base: '#A2217D',
-        hover: '#9C1877',
-        focus: '#950d72',
-      },
-    },
-  },
 }

--- a/src/theme/theme.interface.ts
+++ b/src/theme/theme.interface.ts
@@ -1,15 +1,8 @@
 export interface ColorVariations {
-  base?: string
-  hover?: string
-  focus?: string
-  contrastText?: string
-}
-
-export interface TextColorVariations {
-  base?: string
-  title?: string
-  placeholder?: string
-  disabledPlaceholder?: string
+  base: string
+  hover: string
+  focus: string
+  contrastText: string
 }
 
 export interface ColorFamilies {
@@ -41,15 +34,16 @@ export interface Shadows {
 
 export default interface DesignSystemTheme {
   colors: ColorFamilies
-  textColors: TextColorVariations
+  textColor: string
   backgroundColor: string
   fonts: Fonts
   shadows: Shadows
+  isDark: boolean
 }
 
 export interface GetterProps {
   theme?: {
-    designSystem?: DesignSystemTheme
-    designSystemRoot?: DesignSystemTheme
+    uiCore?: DesignSystemTheme
+    uiCoreRoot?: DesignSystemTheme
   }
 }

--- a/src/theme/theme.stories.tsx
+++ b/src/theme/theme.stories.tsx
@@ -1,19 +1,13 @@
-import { withKnobs, select } from '@storybook/addon-knobs'
+import { withKnobs } from '@storybook/addon-knobs'
 import { storiesOf } from '@storybook/react'
 import * as React from 'react'
 import { config } from 'storybook-addon-designs'
 import styled from 'styled-components'
 
-import Background from '../Background'
-import Button from '../Button'
-import palette from '../palette'
-import Text from '../Text'
-import TextInput from '../TextInput'
 import Title from '../Title'
 import useTheme from '../useTheme'
 
 import theme from './theme'
-import { THEME_PATCHES } from './theme.data'
 import { Shadows } from './theme.interface'
 
 const Container = styled.div`
@@ -56,17 +50,6 @@ const Circle = styled.div<{ color?: string; depth?: keyof Shadows }>`
   }
 `
 
-const ThemePatchContainer = styled.div`
-  max-width: 520px;
-  padding: 24px;
-  display: flex;
-  flex-direction: column;
-
-  & > *:not(:last-child) {
-    margin-bottom: 24px;
-  }
-`
-
 const ThemePatchPalette = () => {
   const { colors } = useTheme()
 
@@ -98,27 +81,13 @@ const ThemePatchPalette = () => {
 
 storiesOf('Utility|theme', module)
   .addDecorator(withKnobs)
-  .add(
-    'colors',
-    () => (
-      <Background
-        backgroundColor={select(
-          'Background color',
-          Object.keys(THEME_PATCHES),
-          '#FFFFFF'
-        )}
-      >
-        <ThemePatchPalette />
-      </Background>
-    ),
-    {
-      design: config({
-        type: 'figma',
-        url:
-          'https://www.figma.com/file/f5tJXjQSoOhy7K3r99pv21Fd/Brand-assets-%26-colors?node-id=8%3A3',
-      }),
-    }
-  )
+  .add('colors', () => <ThemePatchPalette />, {
+    design: config({
+      type: 'figma',
+      url:
+        'https://www.figma.com/file/f5tJXjQSoOhy7K3r99pv21Fd/Brand-assets-%26-colors?node-id=8%3A3',
+    }),
+  })
   .add(
     'shadows',
     () => (
@@ -144,38 +113,6 @@ storiesOf('Utility|theme', module)
         type: 'figma',
         url:
           'https://www.figma.com/file/f5tJXjQSoOhy7K3r99pv21Fd/Brand-assets-%26-colors?node-id=10%3A214',
-      }),
-    }
-  )
-  .add(
-    'patches',
-    () => (
-      <Background
-        backgroundColor={select(
-          'Background color',
-          Object.keys(THEME_PATCHES),
-          palette.darkBlue[900]
-        )}
-      >
-        <ThemePatchContainer>
-          <Title type="section">Exemple de section colorée</Title>
-          <TextInput placeholder="votre@mail.com" />
-          <Text>
-            Les volumes et la forme des pièces sont représentés à titre
-            indicatif. Ils ne constituent pas le plan definitif de votre futur
-            appartement mais bien une suggestion d'agencement. C'est notre
-            architecte qui finalisera ce plan pour vous.
-          </Text>
-          <Button>Bouton</Button>
-          <Button outline>Bouton outline</Button>
-        </ThemePatchContainer>
-      </Background>
-    ),
-    {
-      design: config({
-        type: 'figma',
-        url:
-          'https://www.figma.com/file/f5tJXjQSoOhy7K3r99pv21Fd/Brand-assets-%26-colors?node-id=8%3A3',
       }),
     }
   )

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -67,6 +67,7 @@ const textColorGetter = <Props extends GetterProps>(
     opacity?: number
     useRootTheme?: boolean
     dynamic?: boolean
+    propName?: keyof Props
   } = {}
 ) => (
   props: Props & {
@@ -76,12 +77,16 @@ const textColorGetter = <Props extends GetterProps>(
     opacity?: number
   }
 ) => {
-  const { dynamic = false, useRootTheme = false, opacity } = config
+  const { dynamic = false, useRootTheme = false, opacity, propName } = config
 
   const realOpacity = isNil(props.opacity) ? opacity : props.opacity
 
   const getColor = (): string => {
     const theme = getTheme(props, { useRootTheme })
+
+    if (propName && !isNil(props[propName])) {
+      return (props[propName] as any) as string
+    }
 
     if (!dynamic) {
       return theme.textColor

--- a/src/useTheme.ts
+++ b/src/useTheme.ts
@@ -1,16 +1,14 @@
 import * as React from 'react'
 import { ThemeContext } from 'styled-components'
 
-import { styledTheme } from './_internal/types'
+import { StyledTheme } from './_internal/types'
 import { BASE_THEME } from './theme'
 import DesignSystemTheme from './theme/theme.interface'
 
 const useTheme = (): DesignSystemTheme => {
-  const fullTheme = React.useContext<styledTheme>(ThemeContext)
+  const fullTheme = React.useContext<StyledTheme>(ThemeContext)
 
-  return fullTheme && fullTheme.designSystem
-    ? fullTheme.designSystem
-    : BASE_THEME
+  return fullTheme && fullTheme.uiCore ? fullTheme.uiCore : BASE_THEME
 }
 
 export default useTheme


### PR DESCRIPTION
### Theme management evolution

We now differentiate to types of background evolution :

- Evolution triggered by any "non-white" background. They can by quite complex and necessitate manual CSS, not just theme modifications (for instance the background of an `Input` becomes white when there is a background, even light)

- Evolution triggered by a dark background (the limit is currently : (r + g + b) < 255 * 3 / 2). Right now we switch the text color to white and we apply a new secondary color with nuance of white (not sure if it's a good idea but it's quite hard to avoid unreadable secondary otherwise with our very dark secondary. Maybe we should add a bit of complexity to the theme model but I need concrete feedback for it)

Theme is no more custom theme patches, which was hard to maintain and never used except for one terrible green/blue background with orange text.

### New Components
- `FloatingIconButton`
- `IconButton`


### Storybook improvments
- Remove `colored background` line
- New Story "light background" and "dark background" for relevant components

### Theme breaking changes
- Remove `isRoot` from `ThemeProvider`, if we pass a `theme` then it's a new root, if we pass a `backgroundColor` it's not a new root
- Remove `themeFamily` from `ThemeProvider`, it was a temporary solution for Icade theme on Match, we are now using a proper API based theme
- `theme.textColor` has been totally rewritten. It is now a simple color without variations (like `backgroundColor`). We can still access the basic versions of `primary`, `secondary` and `warning` with the `dynamic` mode (should only be used in `Title` and `Text`, most of the time, the text color should be fixed)


### NavigationDots breaking change
- Remove `secondary` prop which was never defined in the design system