### PR TITLE
APP-24010: change `Lightbox` closing `icon-button` to regular

### DIFF
--- a/src/LightBox/LightBox.tsx
+++ b/src/LightBox/LightBox.tsx
@@ -50,7 +50,6 @@ const InnerLightBox = React.forwardRef<HTMLDivElement, LightBoxInnerProps>(
             data-testid="lightbox-close-icon"
             icon="close"
             onClick={modal.close}
-            large
           />
         )}
         {isFunction(children) ? children(modal) : children}


### PR DESCRIPTION
I am not handling the [mobile version](https://www.figma.com/file/ArudA4kl24Z42ba1Bd0T6j/%F0%9F%A7%A9---Lightbox?node-id=401%3A2042) because I do not know how to take the `title` into account as unlike `modal` there isn't a `title` prop