### PR TITLE
APP-30899: Bump `habx/node` orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ alias:
 
 orbs:
   # docs: https://circleci.com/developer/orbs/orb/habx/node
-  node: habx/node@0.12.0
+  node: habx/node@0.12.1
 
 workflows:
   tests:


### PR DESCRIPTION
See [APP-30899](https://habxfr.atlassian.net/browse/APP-30899): [patch] ui-core: fix(circleci): mssing step.

